### PR TITLE
Fix CurvePreloader resize listener

### DIFF
--- a/components/CurvePreloader/index.tsx
+++ b/components/CurvePreloader/index.tsx
@@ -44,6 +44,7 @@ export default function Curve({ children, backgroundColor }) {
             })
         }
         resize()
+        window.addEventListener('resize', resize)
 
         return () => {
             window.removeEventListener('resize', resize)


### PR DESCRIPTION
## Summary
- attach resize event listener in `CurvePreloader`

## Testing
- `pnpm run lint` *(fails: next not found)*
- `pnpm install` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_6884fbb711ec83228ac7ac467b6a81c5