### PR TITLE
Update license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This blog is based on the [timlrx/tailwind-nextjs-starter-blog](https://github.c
 
 ## License
 
-This project is licensed under the terms of the [license](link-to-your-license-file).
+This project is licensed under the terms of the [license](LICENSE).
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- fix README license link to point to the `LICENSE` file

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fba09e8c8322b6c078d070b11402