### PR TITLE
Add vitest and tests for tailwind helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "serve": "next start",
         "analyze": "cross-env ANALYZE=true next build",
         "lint": "next lint --fix --dir pages --dir app --dir components --dir lib --dir layouts --dir scripts",
-        "prettier": "prettier --write ."
+        "prettier": "prettier --write .",
+        "test": "vitest"
     },
     "dependencies": {
         "@next/bundle-analyzer": "13.4.19",
@@ -79,7 +80,8 @@
         "lint-staged": "^13.0.0",
         "prettier": "^3.0.0",
         "prettier-plugin-tailwindcss": "^0.4.1",
-        "typescript": "^5.1.3"
+        "typescript": "^5.1.3",
+        "vitest": "^1.0.0"
     },
     "resolutions": {
         "@opentelemetry/api": "1.4.1",

--- a/scripts/utils/tailwind-helpers.test.ts
+++ b/scripts/utils/tailwind-helpers.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './tailwind-helpers'
+
+describe('cn utility', () => {
+  it("handles undefined values", () => {
+    expect(cn('a', undefined, 'b')).toBe('a b')
+  })
+
+  it('merges duplicate tailwind classes', () => {
+    expect(cn('bg-red-500', 'bg-blue-500')).toBe('bg-blue-500')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- set up `vitest` with a minimal config
- add a test verifying the `cn` helper
- expose `test` script in `package.json`

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fba1c0f8832284b359473fd35f77